### PR TITLE
Add authentication

### DIFF
--- a/NFC_PN532.py
+++ b/NFC_PN532.py
@@ -166,7 +166,7 @@ class PN532:
         for i, val in enumerate(frame):
             frame[i] = reverse_bit(val)  # turn LSB data to MSB
         if self.debug:
-            print("Reading: ", [hex(i) for i in frame[1:]])
+            print("DEBUG: _read_data: ", [hex(i) for i in frame[1:]])
         return frame[1:]   # don't return the status byte
 
     def _write_data(self, framebytes):
@@ -176,7 +176,7 @@ class PN532:
         rev_frame = [reverse_bit(x)
                      for x in bytes([_SPI_DATAWRITE]) + framebytes]
         if self.debug:
-            print("Writing: ", [hex(i) for i in rev_frame])
+            print("DEBUG: _write_data: ", [hex(i) for i in rev_frame])
         time.sleep(0.02)   # required
         self.CSB.off()
         time.sleep_ms(2)
@@ -210,7 +210,7 @@ class PN532:
         frame[-1] = _POSTAMBLE
         # Send frame.
         if self.debug:
-            print('Write frame: ', [hex(i) for i in frame])
+            print('DEBUG: _write_frame: ', [hex(i) for i in frame])
         self._write_data(bytes(frame))
 
     def _read_frame(self, length):
@@ -222,7 +222,7 @@ class PN532:
         # Read frame with expected length of data.
         response = self._read_data(length+8)
         if self.debug:
-            print('Read frame:', [hex(i) for i in response])
+            print('DEBUG: _read_frame:', [hex(i) for i in response])
 
         # Swallow all the 0x00 values that preceed 0xFF.
         offset = 0
@@ -283,6 +283,8 @@ class PN532:
             return None
         # Read response bytes.
         response = self._read_frame(response_length+2)
+        if(self.debug):
+            print('DEBUG: call_function response:', [hex(i) for i in response])
         # Check that response is for the called function.
         if not (response[0] == _PN532TOHOST and response[1] == (command+1)):
             raise RuntimeError('Received unexpected command response!')


### PR DESCRIPTION
While trying to read data from a card, I realized that "authentication" is a vital part of the way that MIFARE Classic cards work.  Without the authentication, I could not read the data off the card.

This branch ports the mifare_classic_authentication_block() function from the Adafruit library.  This change allows mifare_classic_read_block() to retrieve data from the card.